### PR TITLE
Support decoding the player chat packet

### DIFF
--- a/src/main/java/net/zencraft/velocity/chathistory/SystemChatPacketListener.java
+++ b/src/main/java/net/zencraft/velocity/chathistory/SystemChatPacketListener.java
@@ -31,7 +31,7 @@ public class SystemChatPacketListener extends PacketListenerAbstract {
         }else if(event.getPacketType() == PacketType.Play.Server.CHAT_MESSAGE){
             WrapperPlayServerChatMessage chatMessage = new WrapperPlayServerChatMessage(event);
             Component chatComponent = null;
-            if(chatMessage.getMessage() instanceof ChatMessage_v1_19_3){
+            if(chatMessage.getMessage() instanceof ChatMessage_v1_19_3 && ((ChatMessage_v1_19_3) chatMessage.getMessage()).getUnsignedChatContent().isPresent()){
                 chatComponent = ((ChatMessage_v1_19_3) chatMessage.getMessage()).getUnsignedChatContent().get();
             }
             if(chatComponent == null){

--- a/src/main/java/net/zencraft/velocity/chathistory/SystemChatPacketListener.java
+++ b/src/main/java/net/zencraft/velocity/chathistory/SystemChatPacketListener.java
@@ -4,12 +4,15 @@ import com.github.retrooper.packetevents.event.PacketListenerAbstract;
 import com.github.retrooper.packetevents.event.PacketListenerPriority;
 import com.github.retrooper.packetevents.event.PacketSendEvent;
 import com.github.retrooper.packetevents.protocol.ConnectionState;
+import com.github.retrooper.packetevents.protocol.chat.message.ChatMessage_v1_19_3;
 import com.github.retrooper.packetevents.protocol.packettype.PacketType;
 import com.github.retrooper.packetevents.protocol.player.ClientVersion;
+import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerChatMessage;
 import com.velocitypowered.api.network.ProtocolVersion;
 import com.velocitypowered.api.proxy.Player;
 import com.velocitypowered.proxy.protocol.packet.chat.ComponentHolder;
 import io.netty.buffer.ByteBuf;
+import net.kyori.adventure.text.Component;
 
 public class SystemChatPacketListener extends PacketListenerAbstract {
 
@@ -22,9 +25,19 @@ public class SystemChatPacketListener extends PacketListenerAbstract {
         Player player = (Player) event.getPlayer();
         if(event.getConnectionState() != ConnectionState.PLAY)return;
         if(event.getUser().getClientVersion().isOlderThan(ClientVersion.V_1_20_2))return;
-        if (event.getPacketType() == PacketType.Play.Server.SYSTEM_CHAT_MESSAGE) {
+        if(event.getPacketType() == PacketType.Play.Server.SYSTEM_CHAT_MESSAGE){
             ComponentHolder component = ComponentHolder.read((ByteBuf) event.getByteBuf(), ProtocolVersion.MINECRAFT_1_20_3);
             ChatHistory.getInstance().addMessage(player, component.getComponent());
+        }else if(event.getPacketType() == PacketType.Play.Server.CHAT_MESSAGE){
+            WrapperPlayServerChatMessage chatMessage = new WrapperPlayServerChatMessage(event);
+            Component chatComponent = null;
+            if(chatMessage.getMessage() instanceof ChatMessage_v1_19_3){
+                chatComponent = ((ChatMessage_v1_19_3) chatMessage.getMessage()).getUnsignedChatContent().get();
+            }
+            if(chatComponent == null){
+                chatComponent = chatMessage.getMessage().getChatContent();
+            }
+            ChatHistory.getInstance().addMessage(player, chatComponent);
         }
     }
 


### PR DESCRIPTION
This patch adds support for decoding the player chat packet as described [here](https://wiki.vg/Protocol#Player_Chat_Message) in addition to the system chat messages already supported.
This resolves #1 and improves support for a variety of situations.

I have only done minimal testing with my configuration though, so I do not know how this patch will interact with other configurations or vanilla chat.