### PR TITLE
Ignore ActionBar messages in System Chat packets

### DIFF
--- a/src/main/java/net/zencraft/velocity/chathistory/SystemChatPacketListener.java
+++ b/src/main/java/net/zencraft/velocity/chathistory/SystemChatPacketListener.java
@@ -24,7 +24,9 @@ public class SystemChatPacketListener extends PacketListenerAbstract {
         if(event.getUser().getClientVersion().isOlderThan(ClientVersion.V_1_20_2))return;
         if (event.getPacketType() == PacketType.Play.Server.SYSTEM_CHAT_MESSAGE) {
             ComponentHolder component = ComponentHolder.read((ByteBuf) event.getByteBuf(), ProtocolVersion.MINECRAFT_1_20_3);
-            ChatHistory.getInstance().addMessage(player, component.getComponent());
+            boolean isActionBar = ((ByteBuf)event.getByteBuf()).readBoolean();
+            if (!isActionBar)
+                ChatHistory.getInstance().addMessage(player, component.getComponent());
         }
     }
 


### PR DESCRIPTION
This avoids the chat spam that occurs when ActionBar messages have been sent to the player prior to changing servers. Since there's no point tracking them, this ignores any System Chat packets with the [ActionBar flag](https://wiki.vg/Protocol#System_Chat_Message) set.

Fixes issue #5 